### PR TITLE
#32 PostgreSQL 인덱스 리스트 API 생성

### DIFF
--- a/src/main/java/com/example/spectra/controller/api/MonitoringController.java
+++ b/src/main/java/com/example/spectra/controller/api/MonitoringController.java
@@ -56,6 +56,11 @@ public class MonitoringController {
         return monitoringService.getUnusedIndexes(map, pageNum);
     }
 
+    @GetMapping("/all-indexes")
+    public List<IndexDTO> getAllIndexes(@RequestParam Map<String, Object> map, @RequestParam(defaultValue = "1") int pageNum) {
+        return monitoringService.getAllIndexes(map, pageNum);
+    }
+
     @GetMapping("/top5-indexes")
     public List<MonitoringDTO> getTop5Indexes() {
         return monitoringService.getTop5Indexes();

--- a/src/main/java/com/example/spectra/repository/dynamic/MonitoringRepository.java
+++ b/src/main/java/com/example/spectra/repository/dynamic/MonitoringRepository.java
@@ -19,4 +19,8 @@ public class MonitoringRepository implements SqlSessionTemplateAware {
     public List<IndexDTO> getUnusedIndexes(Map<String, Object> map) {
         return sqlSessionTemplate.selectList(DynamicDataSourceConfig.getNamespace() + ".MonitoringMapper.getUnusedIndexes", map);
     }
+
+    public List<IndexDTO> getAllIndexes(Map<String, Object> map) {
+        return sqlSessionTemplate.selectList(DynamicDataSourceConfig.getNamespace() + ".MonitoringMapper.getAllIndexesList", map);
+    }
 }

--- a/src/main/java/com/example/spectra/service/MonitoringService.java
+++ b/src/main/java/com/example/spectra/service/MonitoringService.java
@@ -47,6 +47,12 @@ public class MonitoringService {
         return monitoringRepository.getUnusedIndexes(map);
     }
 
+    public List<IndexDTO> getAllIndexes(Map<String, Object> map, int pageNum) {
+        map.put("limit", Constants.PAGE_SIZE);
+        map.put("offset", (pageNum - 1) * Constants.PAGE_SIZE);
+        return monitoringRepository.getAllIndexes(map);
+    }
+
     public List<MonitoringDTO> getTop5Indexes() {
         return List.of(new MonitoringDTO());
     }

--- a/src/main/resources/mapper/postgres/MonitoringMapper.xml
+++ b/src/main/resources/mapper/postgres/MonitoringMapper.xml
@@ -18,7 +18,7 @@
             LIMIT #{limit} OFFSET #{offset}
     </select>
 
-    <select id="getAllIndexesList" resultType="IndexDTO">
+    <select id="getAllIndexesList" resultType="IndexDTO" parameterType="Map">
         SELECT schemaname, tablename, indexname, tablespace, indexdef
         FROM pg_indexes
         ORDER BY indexrelid

--- a/src/main/resources/mapper/postgres/MonitoringMapper.xml
+++ b/src/main/resources/mapper/postgres/MonitoringMapper.xml
@@ -18,4 +18,10 @@
             LIMIT #{limit} OFFSET #{offset}
     </select>
 
+    <select id="getAllIndexesList" resultType="IndexDTO">
+        SELECT schemaname, tablename, indexname, tablespace, indexdef
+        FROM pg_indexes
+        ORDER BY indexrelid
+             LIMIT #{limit} OFFSET #{offset}
+    </select>
 </mapper>

--- a/src/test/java/com/example/spectra/service/MonitoringServiceTest.java
+++ b/src/test/java/com/example/spectra/service/MonitoringServiceTest.java
@@ -48,4 +48,12 @@ public class MonitoringServiceTest {
         List<IndexDTO> unusedIndexList = monitoringService.getUnusedIndexes(map, 1);
         assertEquals(unusedIndexList.size(), Constants.PAGE_SIZE);
     }
+
+    @Test
+    @DisplayName("모든 인덱스 리스트 조회")
+    public void shouldSelectAllIndexList() throws Exception {
+        Map<String, Object> map = new HashMap<>();
+        List<IndexDTO> allIndexesList = monitoringService.getAllIndexes(map, 1);
+        assertEquals(allIndexesList.size(), Constants.PAGE_SIZE);
+    }
 }


### PR DESCRIPTION
## 관련 이슈 (Related Issues)

<!--
관련된 이슈 번호를 나열해주세요. 예: #123
--> #32

- 관련 이슈 1 (#32)
## 설명 (Description)

PostgreSQL 데이터베이스에서 인덱스 전체 리스트를 가져와 해당 정보를 노출시키는 백엔드 API를 생성합니다.
PostgreSQL 데이터베이스에서 인덱스 리스트를 가져오는 쿼리 작성 및 페이징 처리를 구현합니다.


## 변경 사항 (Changes)

- monitoringMapper.xml에 pg_indexes 테이블에서 인덱스 정보를 조회하는 쿼리 추가
- "/all-indexes"경로로 GetMapping을 받아 인덱스 리스트를 리턴하는 코드 추가
- MonitoringServiceTest에 테스트 추가. 


## 체크리스트 (Checklist)

- [x ] 코드가 제대로 동작하는지 테스트했습니다.  
 -> 프로젝트 설정의 문제인지, 의존성의 문제인지 테스트 코드는 작동되지 않고있습니다. 참고한 shouldSelectUnusedIndexList() 테스트도 fail이 되고있어서 일단 같은 내용으로 작성하여 커밋했습니다. 제가 해결할 수 있는 부분이 있을까요?

- [x] 문서를 적절하게 업데이트했습니다.
-> 제가 업데이트해야 하는 문서가 있다면 말씀 부탁드립니다! 
